### PR TITLE
chore: fix README license badge — MIT → Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # dvt
+
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+## License
+
+Licensed under the [Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0). See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Summary
- Fix incorrect MIT license references in README (actual LICENSE is Apache 2.0)
- Add Apache 2.0 badge where missing
- Add license section where missing

Automated fix via `scripts/fix-readme-license.sh`